### PR TITLE
reimplement zstd without sync pool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.11
 require (
 	github.com/frankban/quicktest v1.10.1 // indirect
 	github.com/golang/snappy v0.0.1
-	github.com/klauspost/compress v1.11.2
+	github.com/klauspost/compress v1.11.3
 	github.com/pierrec/lz4 v2.5.2+incompatible
 	google.golang.org/grpc v1.31.0
 )

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/klauspost/compress v1.11.2 h1:MiK62aErc3gIiVEtyzKfeOHgW7atJb5g/KNX5m3c2nQ=
-github.com/klauspost/compress v1.11.2/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.11.3 h1:dB4Bn0tN3wdCzQxnS8r06kV74qN/TAfaIS0bVE8h3jc=
+github.com/klauspost/compress v1.11.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/zstd/zstd.go
+++ b/zstd/zstd.go
@@ -1,65 +1,43 @@
-/*
- *
- * Copyright 2017 gRPC authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
+// Copyright 2020 Mostyn Bramley-Moore.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // Package zstd is a wrapper for using github.com/klauspost/compress/zstd
 // with gRPC.
 package zstd
 
-// This code is based upon the gzip wrapper in github.com/grpc/grpc-go:
-// https://github.com/grpc/grpc-go/blob/master/encoding/gzip/gzip.go
-
 import (
+	"bytes"
 	"io"
 	"io/ioutil"
-	"runtime"
-	"sync"
 
-	zstdlib "github.com/klauspost/compress/zstd"
+	"github.com/klauspost/compress/zstd"
 	"google.golang.org/grpc/encoding"
 )
 
 const Name = "zstd"
 
 type compressor struct {
-	poolCompressor   sync.Pool
-	poolDecompressor sync.Pool
-}
-
-type writer struct {
-	*zstdlib.Encoder
-	pool *sync.Pool
-}
-
-type reader struct {
-	*zstdlib.Decoder
-	pool *sync.Pool
+	encoder *zstd.Encoder
+	decoder *zstd.Decoder
 }
 
 func init() {
-	c := &compressor{}
-	c.poolCompressor.New = func() interface{} {
-		w, err := zstdlib.NewWriter(ioutil.Discard)
-		if err != nil {
-			panic(err)
-		}
-		writer := &writer{Encoder: w, pool: &c.poolCompressor}
-		runtime.SetFinalizer(writer, finalizeWriter)
-		return writer
+	enc, _ := zstd.NewWriter(nil)
+	dec, _ := zstd.NewReader(nil)
+	c := &compressor{
+		encoder: enc,
+		decoder: dec,
 	}
 	encoding.RegisterCompressor(c)
 }
@@ -67,73 +45,55 @@ func init() {
 // SetLevel updates the registered compressor to use a particular compression
 // level. NOTE: this function must only be called from an init function, and
 // is not threadsafe.
-func SetLevel(level zstdlib.EncoderLevel) error {
+func SetLevel(level zstd.EncoderLevel) error {
 	c := encoding.GetCompressor(Name).(*compressor)
-	c.poolCompressor.New = func() interface{} {
-		w, err := zstdlib.NewWriter(ioutil.Discard,
-			zstdlib.WithEncoderLevel(level))
-		if err != nil {
-			return err
-		}
 
-		writer := &writer{Encoder: w, pool: &c.poolCompressor}
-		runtime.SetFinalizer(writer, finalizeWriter)
-		return writer
+	enc, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(level))
+	if err != nil {
+		return err
 	}
 
+	c.encoder = enc
 	return nil
 }
 
 func (c *compressor) Compress(w io.Writer) (io.WriteCloser, error) {
-	z := c.poolCompressor.Get().(*writer)
-	z.Encoder.Reset(w)
-	return z, nil
+	return &zstdWriteCloser{
+		enc:    c.encoder,
+		writer: w,
+	}, nil
+}
+
+type zstdWriteCloser struct {
+	enc    *zstd.Encoder
+	writer io.Writer    // Compressed data will be written here.
+	buf    bytes.Buffer // Buffer uncompressed data here, compress on Close.
+}
+
+func (z *zstdWriteCloser) Write(p []byte) (int, error) {
+	return z.buf.Write(p)
+}
+
+func (z *zstdWriteCloser) Close() error {
+	compressed := z.enc.EncodeAll(z.buf.Bytes(), nil)
+	_, err := io.Copy(z.writer, bytes.NewReader(compressed))
+	return err
 }
 
 func (c *compressor) Decompress(r io.Reader) (io.Reader, error) {
-	z, inPool := c.poolDecompressor.Get().(*reader)
-	if !inPool {
-		newZ, err := zstdlib.NewReader(r)
-		if err != nil {
-			return nil, err
-		}
-		reader := &reader{Decoder: newZ, pool: &c.poolDecompressor}
-		runtime.SetFinalizer(reader, finalizeReader)
-		return reader, nil
-	}
-	if err := z.Reset(r); err != nil {
-		c.poolDecompressor.Put(z)
+	compressed, err := ioutil.ReadAll(r)
+	if err != nil {
 		return nil, err
 	}
-	return z, nil
+
+	uncompressed, err := c.decoder.DecodeAll(compressed, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return bytes.NewReader(uncompressed), nil
 }
 
 func (c *compressor) Name() string {
 	return Name
-}
-
-func (z *writer) Close() error {
-	err := z.Encoder.Close()
-	z.pool.Put(z)
-	return err
-}
-
-func (z *reader) Read(p []byte) (n int, err error) {
-	n, err = z.Decoder.Read(p)
-	if err == io.EOF {
-		z.pool.Put(z)
-	}
-	return n, err
-}
-
-func finalizeReader(r *reader) {
-	if r.Decoder != nil {
-		r.Decoder.Close()
-	}
-}
-
-func finalizeWriter(w *writer) {
-	if w.Encoder != nil {
-		w.Encoder.Close()
-	}
 }


### PR DESCRIPTION
This change reimplements the zstd support without using a sync.Pool and the tricky finalizer setup.