### PR TITLE
upgrade github.com/klauspost/compress to v1.13.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.11
 require (
 	github.com/frankban/quicktest v1.10.1 // indirect
 	github.com/golang/snappy v0.0.3
-	github.com/klauspost/compress v1.13.0
+	github.com/klauspost/compress v1.13.3
 	github.com/pierrec/lz4 v2.5.2+incompatible
 	google.golang.org/grpc v1.31.0
 )

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/klauspost/compress v1.13.0 h1:2T7tUoQrQT+fQWdaY5rjWztFGAFwbGD04iPJg90ZiOs=
-github.com/klauspost/compress v1.13.0/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
+github.com/klauspost/compress v1.13.3 h1:BtAvtV1+h0YwSVwWoYXMREPpYu9VzTJ9QDI1TEg/iQQ=
+github.com/klauspost/compress v1.13.3/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=


### PR DESCRIPTION
This includes the following zstd improvements since v1.13.0:

* Add configurable Decoder window size
  https://github.com/klauspost/compress/pull/394
* Add stream content size
  https://github.com/klauspost/compress/pull/401
* Simplify hashing functions
  https://github.com/klauspost/compress/pull/402
* use SpeedBestCompression for level >= 10
  https://github.com/klauspost/compress/pull/410
* Fix WriteTo error forwarding
  https://github.com/klauspost/compress/pull/411
* Improve Best compression
  https://github.com/klauspost/compress/pull/404