### PR TITLE
Set friendlier zstd options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+
+.idea

--- a/zstd/zstd.go
+++ b/zstd/zstd.go
@@ -27,14 +27,30 @@ import (
 
 const Name = "zstd"
 
+var encoderOptions = []zstd.EOption{
+	// The default zstd window size is 8MB, which is much larger than the
+	// typical RPC message and wastes a bunch of memory.
+	zstd.WithWindowSize(512 * 1024),
+	// By default zstd uses GOMAXPROCS (64 in prod) threads to encode a
+	// given input, which is overkill for a typical RPC message and
+	// further wastes memory.
+	zstd.WithEncoderConcurrency(1),
+}
+
+var decoderOptions = []zstd.DOption{
+	// Similar, zstd uses GOMAXPROCS threads for decoding, which is
+	// overkill.
+	zstd.WithDecoderConcurrency(1),
+}
+
 type compressor struct {
 	encoder *zstd.Encoder
 	decoder *zstd.Decoder
 }
 
 func init() {
-	enc, _ := zstd.NewWriter(nil)
-	dec, _ := zstd.NewReader(nil)
+	enc, _ := zstd.NewWriter(nil, encoderOptions...)
+	dec, _ := zstd.NewReader(nil, decoderOptions...)
 	c := &compressor{
 		encoder: enc,
 		decoder: dec,

--- a/zstd/zstd.go
+++ b/zstd/zstd.go
@@ -31,16 +31,6 @@ var encoderOptions = []zstd.EOption{
 	// The default zstd window size is 8MB, which is much larger than the
 	// typical RPC message and wastes a bunch of memory.
 	zstd.WithWindowSize(512 * 1024),
-	// By default zstd uses GOMAXPROCS (64 in prod) threads to encode a
-	// given input, which is overkill for a typical RPC message and
-	// further wastes memory.
-	zstd.WithEncoderConcurrency(1),
-}
-
-var decoderOptions = []zstd.DOption{
-	// Similar, zstd uses GOMAXPROCS threads for decoding, which is
-	// overkill.
-	zstd.WithDecoderConcurrency(1),
 }
 
 type compressor struct {
@@ -50,7 +40,7 @@ type compressor struct {
 
 func init() {
 	enc, _ := zstd.NewWriter(nil, encoderOptions...)
-	dec, _ := zstd.NewReader(nil, decoderOptions...)
+	dec, _ := zstd.NewReader(nil)
 	c := &compressor{
 		encoder: enc,
 		decoder: dec,


### PR DESCRIPTION
During a recent deploy, we noticed that our encoding options were no longer being set for the zstd encoder and decoder. The lack of these options almost 2x'ed our memory usage. Given that this library is used mostly for RPC, we thought it would be good to upstream these so that everyone could see reduced memory usage.

<img width="1468" alt="Screenshot 2023-06-08 at 11 54 58 AM" src="https://github.com/mostynb/go-grpc-compression/assets/10070047/fbbfa971-d04c-4937-a31b-888377509869">

<img width="627" alt="Screenshot 2023-06-08 at 11 56 46 AM" src="https://github.com/mostynb/go-grpc-compression/assets/10070047/13e7c166-cf27-4fc8-ad4d-e35a9fe41cda">
