### PR TITLE
Avoid clobbering already-registered compressors, for safety

### DIFF
--- a/internal/deptest/deptest_test.go
+++ b/internal/deptest/deptest_test.go
@@ -1,0 +1,43 @@
+// Copyright 2020 Mostyn Bramley-Moore.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// package deptest ensures that the go-grpc-compression sub-packages will
+// not clobber an existing registration.
+package deptest
+
+import (
+	"testing"
+
+	// This import happens first for the test, keep it ahead of
+	// the three unnamed imports below.
+	"github.com/mostynb/go-grpc-compression/internal/deptest/testlib"
+
+	// If these were moved above, the test would fail because
+	// testlib has the same no-clobber logic as the main packages.
+	_ "github.com/mostynb/go-grpc-compression/lz4"
+	_ "github.com/mostynb/go-grpc-compression/snappy"
+	_ "github.com/mostynb/go-grpc-compression/zstd"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/encoding"
+)
+
+func TestCompressorNotClobbered(t *testing.T) {
+	// Because the deptest/lib imports first, it's init() function
+	// registers dummy compressors. The following libraries do not
+	// clobber, so we should find Dummy compressors.
+	for _, name := range testlib.AllNames {
+		_, ok := encoding.GetCompressor(name).(testlib.Dummy)
+		require.True(t, ok)
+	}
+}

--- a/internal/deptest/testlib/testlib.go
+++ b/internal/deptest/testlib/testlib.go
@@ -1,0 +1,52 @@
+// Copyright 2020 Mostyn Bramley-Moore.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testlib
+
+import (
+	"fmt"
+	"io"
+
+	"google.golang.org/grpc/encoding"
+)
+
+type Dummy string
+
+var _ encoding.Compressor = Dummy("")
+
+// AllNames lists every compressor in this repo, for testing.
+var AllNames = []string{"zstd", "snappy", "lz4"}
+
+func (d Dummy) Compress(io.Writer) (io.WriteCloser, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (d Dummy) Decompress(r io.Reader) (io.Reader, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (d Dummy) Name() string {
+	return string(d)
+}
+
+func init() {
+	for _, name := range AllNames {
+		// This test will not register the dummies in case
+		// of existing registrations, this ensures the import
+		// order of the deptest actually tests no-clobbering.
+		if encoding.GetCompressor(name) == nil {
+			encoding.RegisterCompressor(Dummy(name))
+		}
+	}
+}

--- a/lz4/lz4.go
+++ b/lz4/lz4.go
@@ -54,7 +54,9 @@ func init() {
 		w := lz4lib.NewWriter(ioutil.Discard)
 		return &writer{Writer: w, pool: &c.poolCompressor}
 	}
-	encoding.RegisterCompressor(c)
+	if encoding.GetCompressor(c.Name()) == nil {
+		encoding.RegisterCompressor(c)
+	}
 }
 
 func (c *compressor) Compress(w io.Writer) (io.WriteCloser, error) {

--- a/snappy/snappy.go
+++ b/snappy/snappy.go
@@ -54,7 +54,9 @@ func init() {
 		w := snappylib.NewBufferedWriter(ioutil.Discard)
 		return &writer{Writer: w, pool: &c.poolCompressor}
 	}
-	encoding.RegisterCompressor(c)
+	if encoding.GetCompressor(c.Name()) == nil {
+		encoding.RegisterCompressor(c)
+	}
 }
 
 func (c *compressor) Compress(w io.Writer) (io.WriteCloser, error) {

--- a/zstd/zstd.go
+++ b/zstd/zstd.go
@@ -45,7 +45,9 @@ func init() {
 		encoder: enc,
 		decoder: dec,
 	}
-	encoding.RegisterCompressor(c)
+	if encoding.GetCompressor(c.Name()) == nil {
+		encoding.RegisterCompressor(c)
+	}
 }
 
 // SetLevel updates the registered compressor to use a particular compression


### PR DESCRIPTION
My company recently had a production incident caused by this library clobbering already-registered encodings which used the settings found in https://github.com/mostynb/go-grpc-compression/pull/17.  Since the OpenTelemetry collector depends on this library, when our company internally began using the OpenTelemetry collector core libraries and it changed our zstd settings inadvertently.

We think it would be also prudent to avoid clobbering these registrations by checking for an existing encoding by the same name before registering the new one during the `init()` functions in this package.